### PR TITLE
rspec-1143: fix for false positives

### DIFF
--- a/bblfsh_sonar_checks/checks/java/RSPEC-1143.py
+++ b/bblfsh_sonar_checks/checks/java/RSPEC-1143.py
@@ -8,11 +8,14 @@ def check(uast):
     fnls = bblfsh.filter(uast, "//*[@roleFinally]")
 
     for f in fnls:
-        throws = bblfsh.filter(uast, "//*[@roleThrow or @roleReturn]")
+        throws = bblfsh.filter(f, "//*[@roleThrow or @roleReturn]")
 
         for t in throws:
-            findings.append({"msg": "Don't throw or return inside a finally (line {})",
-                             "pos": t.start_position})
+            findings.append({
+                "msg": "Don't throw or return inside a finally (line {})".format(
+                        t.start_position.col),
+                "pos": t.start_position
+            })
 
     return findings
 

--- a/bblfsh_sonar_checks/fixtures/java/RSPEC-1143.java
+++ b/bblfsh_sonar_checks/fixtures/java/RSPEC-1143.java
@@ -6,4 +6,7 @@ class ThrowInFinally {
             return;
         }
     }
+    void test2() {
+        throw new RuntimeException();
+    }
 }


### PR DESCRIPTION
Resolves #2

Test plan:

```
$ python3 -m bblfsh_sonar_checks --language=java --enable=RSPEC-1143 ./bblfsh_sonar_checks/fixtures/java/RSPEC-1143.java
```

Results in only 2 messages.

