### PR TITLE
Ensure JSON output

### DIFF
--- a/bblfsh_sonar_checks/__main__.py
+++ b/bblfsh_sonar_checks/__main__.py
@@ -6,8 +6,9 @@ import sys
 from typing import Set
 
 from bblfsh_sonar_checks import (
-        run_check, run_checks, list_checks, get_check_description
+        run_checks, list_checks, get_check_description
 )
+
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -32,7 +33,6 @@ def parse_arguments() -> argparse.Namespace:
                 ncheck = "RSPEC-{}".format(check)
 
         return ncheck
-
 
     args.checks: Set[str] = set()
 
@@ -63,15 +63,15 @@ def _list(lang):
 def main() -> None:
     args = parse_arguments()
 
-    import  bblfsh
-    from pprint import pprint
+    import bblfsh
 
     client = bblfsh.BblfshClient(args.ip + ":" + args.port)
     parse_result = client.parse(args.file)
     if parse_result.status != 0:
         print(json.dumps(parse_result.errors))
 
-    print(run_checks(args.checks, args.language, parse_result.uast, json_result=True))
+    print(json.dumps(run_checks(args.checks, args.language, parse_result.uast, json_result=False)))
+
 
 if __name__ == "__main__":
     main()

--- a/bblfsh_sonar_checks/__main__.py
+++ b/bblfsh_sonar_checks/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import json
 import sys
 from typing import Set
 
@@ -68,10 +69,9 @@ def main() -> None:
     client = bblfsh.BblfshClient(args.ip + ":" + args.port)
     parse_result = client.parse(args.file)
     if parse_result.status != 0:
-        print(parse_result.errors)
+        print(json.dumps(parse_result.errors))
 
-    pprint(run_checks(args.checks, args.language, parse_result.uast))
-
+    print(run_checks(args.checks, args.language, parse_result.uast, json_result=True))
 
 if __name__ == "__main__":
     main()

--- a/bblfsh_sonar_checks/utils.py
+++ b/bblfsh_sonar_checks/utils.py
@@ -1,6 +1,7 @@
 import glob
 import importlib
 import inspect
+import json
 import os
 import sys
 from typing import List, Dict, Any
@@ -222,7 +223,9 @@ class RunCheckException(Exception):
     pass
 
 
-def run_check(check_code: str, lang: str, uast) -> List[Dict[str, Any]]:
+def run_check(check_code: str, lang: str, uast, json_result: bool = False) \
+        -> List[Dict[str, Any]]:
+
     check_code = check_code.upper()
     check_path = os.path.join(THIS_PATH, "checks", lang, check_code + ".py")
 
@@ -236,15 +239,23 @@ def run_check(check_code: str, lang: str, uast) -> List[Dict[str, Any]]:
     for c in checks:
         if "pos" not in c:
             c["pos"] = None
+        else:
+            p = c["pos"]
+            c["pos"] = {"line": p.line, "col": p.col, "offset": p.offset}
+
+    if json_result:
+        checks = [json.dumps(i) for i in checks]
 
     return checks
 
 
-def run_checks(check_codes: List[str], lang: str, uast) -> Dict[str, List[Dict[str, Any]]]:
+def run_checks(check_codes: List[str], lang: str, uast, json_result: bool = False) \
+        -> Dict[str, List[Dict[str, Any]]]:
+
     res: Dict[str, List[Dict[str, Any]]] = {}
 
     for code in check_codes:
-        res[code] = run_check(code, lang, uast)
+        res[code] = run_check(code, lang, uast, json_result)
 
     return res
 

--- a/bblfsh_sonar_checks/utils.py
+++ b/bblfsh_sonar_checks/utils.py
@@ -130,7 +130,7 @@ def get_methods(node: bblfsh.Node) -> List[Method]:
     return [Method(i) for i in bblfsh.filter(node, "//TypeDeclaration//FunctionGroup")]
 
 
-def hash_node(node: bblfsh.Node, ignore_sideness: bool=True) -> hashlib._Hash:
+def hash_node(node: bblfsh.Node, ignore_sideness: bool=True) -> hashlib._hashlib.HASH:
     """ Hashes a node ignoring positional information """
 
     lroles = [str(i) for i in node.roles if i not in (bblfsh.role_id("LEFT"),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 description = long_descr = "Library implementing Sonar Source checks using the babelfish project"
 
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 setup(
         name = "bblfsh_sonar_checks",


### PR DESCRIPTION
Fixes #4.

Adds a `json_output` parameter to the `run_check` and `run_checks` functions which is always set to `True` when running from the command line.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>