### PR TITLE
utils: add method to list supported languages

### DIFF
--- a/bblfsh_sonar_checks/utils.py
+++ b/bblfsh_sonar_checks/utils.py
@@ -279,6 +279,10 @@ def run_default_fixture(path: str, check_fnc: CheckFnc, conn_str: str = "0.0.0.0
 
     return res
 
+def list_langs() -> List[str]:
+    langs_path = os.path.join(THIS_PATH, "checks")
+    return list(filter(lambda x: not x.startswith("_"), next(os.walk(langs_path))[1]))
+
 
 def list_checks(lang: str) -> List[str]:
     checks_path = os.path.join(THIS_PATH, "checks", lang)


### PR DESCRIPTION
Adds a method to list supported languages, same way as supported checks are listed for each language.

A client will use it to run checks on every changed file:

```python
            check_results = run_checks(
                list_checks(change.head.language.lower()),
                change.head.language.lower(),
                change.head.uast
            )
```
